### PR TITLE
[#3] Remove upper bounds

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -23,12 +23,12 @@ description:         Please see the README on GitHub at <https://github.com/aksh
 tested-with: GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5
 
 dependencies:
-- aeson                >= 1.1 && < 1.5
-- attoparsec           >= 0.13 && < 0.14
+- aeson                >= 1.1
+- attoparsec           >= 0.13
 - base                 >= 4.9 && < 5
-- text                 >= 1.2 && < 1.3
-- unordered-containers >= 0.2.8 && < 0.3
-- vector               >= 0.12 && < 0.13
+- text                 >= 1.2
+- unordered-containers >= 0.2.8
+- vector               >= 0.12
 
 library:
   source-dirs: src


### PR DESCRIPTION
Should #3 be approved, this removes the upper bounds on the basic
dependencies of this package with the idea that with few exceptions
this does not cause any issues other than those caught at compile-time
and decreases all the endless version bound fiddling you have to do as
other dependencies advance.