### PR TITLE
Allow selecting keys in unions and allow many union elements

### DIFF
--- a/src/Data/JSONPath/Types.hs
+++ b/src/Data/JSONPath/Types.hs
@@ -3,7 +3,7 @@ module Data.JSONPath.Types
     Condition (..),
     Literal (..),
     JSONPathElement (..),
-    SliceElement (..),
+    UnionElement (..),
   )
 where
 
@@ -28,16 +28,18 @@ data Literal
   | LitString Text
   deriving (Show, Eq)
 
-data SliceElement
-  = SingleIndex Int
-  | MultipleIndices (Maybe Int) (Maybe Int) (Maybe Int)
+data UnionElement
+  = UEKeyChild Text
+  | UEIndexChild Int
+  | UESlice (Maybe Int) (Maybe Int) (Maybe Int)
   deriving (Show, Eq)
 
 data JSONPathElement
   = KeyChild Text
+  | IndexChild Int
   | AnyChild
-  | Slice SliceElement
-  | SliceUnion SliceElement SliceElement
+  | Slice (Maybe Int) (Maybe Int) (Maybe Int)
+  | Union [UnionElement]
   | Filter BeginningPoint [JSONPathElement] Condition Literal
   | Search [JSONPathElement]
   deriving (Show, Eq)

--- a/test/resources/json-path-tests/IndexedSubscriptOperator.json
+++ b/test/resources/json-path-tests/IndexedSubscriptOperator.json
@@ -6,7 +6,8 @@
         "Architect",
         "one",
         "three",
-        "five"
+        "five",
+        {"string": "str", "array": ["arr"]}
     ],
     "tests" : [{
         "path" : "$[2]",
@@ -16,7 +17,7 @@
             "result" : ["Architect"]
         },{
             "path" : "$[-1]",
-            "result" : ["five"]
+            "result" : [{"string": "str", "array": ["arr"]}]
         }, {
             "path" : "$[10]",
             "result" : []
@@ -37,10 +38,10 @@
             "result" : [36, "one", "five"]
         }, {
             "path" : "$[::2]",
-            "result" : ["John Doe", "Architect", "three"]
+            "result" : ["John Doe", "Architect", "three", {"string": "str", "array": ["arr"]}]
         }, {
             "path" : "$[1:]",
-            "result" : [36, "Architect", "one", "three", "five"]
+            "result" : [36, "Architect", "one", "three", "five", {"string": "str", "array": ["arr"]}]
         }, {
             "path" : "$[:3]",
             "result" : ["John Doe", 36, "Architect"]
@@ -59,12 +60,21 @@
         }, {
             "path" : "$[ 0:2 , 4]",
             "result" : ["John Doe", 36, "three"]
-        } , {
+        }, {
+            "path" : "$[0:2, 'foo']",
+            "result" : ["John Doe", 36]
+        }, {
+            "path" : "$[-1]['string', 'array']",
+            "result" : ["str", ["arr"]]
+        }, {
+            "path" : "$[-1][\"not-here\", \"array\", \"string\"]",
+            "result" : [["arr"], "str"]
+        }, {
             "path" : "$[*]",
-            "result" : ["John Doe", 36, "Architect", "one", "three", "five"]
+            "result" : ["John Doe", 36, "Architect", "one", "three", "five", {"string": "str", "array": ["arr"]}]
         }, {
             "path": "$[2:113667776004]",
-            "result": ["Architect", "one", "three", "five"]
+            "result": ["Architect", "one", "three", "five", {"string": "str", "array": ["arr"]}]
         }, {
             "path": "$[-113667776004:2]",
             "result": ["John Doe", 36]
@@ -87,14 +97,16 @@
                 "three",
                 "one",
                 "Architect",
-                36
+                36,
+                {"string": "str", "array": ["arr"]}
             ]
         }, {
             "path": "$[::-2]",
             "result": [
-                "five",
-                "one",
-                36
+                {"string": "str", "array": ["arr"]},
+                "three",
+                "Architect",
+                "John Doe"
             ]
         }, {
             "path": "$[::]",
@@ -104,7 +116,8 @@
                 "Architect",
                 "one",
                 "three",
-                "five"
+                "five",
+                {"string": "str", "array": ["arr"]}
             ]
         }
     ]


### PR DESCRIPTION
Breaking:
- `SliceElement` is replaced by `UnionElement`
- The constructor `Slice` now only represents `[start:end:step]` kind of selector.
Selecting elements by single index is represented by constructor `IndexChild`
- The `Union` constructor takes a `[UnionElement]` instead of just 2
`SliceElement`s